### PR TITLE
refactor: Move to using services as public

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -12,7 +12,7 @@
       },
       "root": "",
       "sourceRoot": "src",
-      "prefix": "app",
+      "prefix": "pwui",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,1 @@
-<app-options></app-options> <app-meeting></app-meeting>
+<pwui-options></pwui-options> <pwui-meeting></pwui-meeting>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,18 +1,17 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 
 import { DeviceManagerService } from './services/DeviceManager/deviceManager.service';
 import { ConfigurationService } from './services/Configuration/configuration.service';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { MeetingComponent } from './components/meeting/meeting.component';
-import { OptionsComponent } from './components/options/options.component';
+import { MeetingModule } from './components/meeting/meeting.module';
+import { OptionsModule } from './components/options/options.module';
 
 @NgModule({
-  declarations: [AppComponent, MeetingComponent, OptionsComponent],
-  imports: [BrowserModule, AppRoutingModule, FormsModule],
+  declarations: [AppComponent],
+  imports: [BrowserModule, AppRoutingModule, OptionsModule, MeetingModule],
   providers: [DeviceManagerService, ConfigurationService],
   bootstrap: [AppComponent],
 })

--- a/src/app/components/meeting/meeting.component.spec.ts
+++ b/src/app/components/meeting/meeting.component.spec.ts
@@ -4,9 +4,9 @@ import { MeetingComponent } from './meeting.component';
 import { DeviceManagerService } from 'src/app/services/DeviceManager/deviceManager.service';
 
 const mockDeviceManager = {
-  getVideoDeviceInfo: jest.fn(),
-  getAudioInputDeviceInfo: jest.fn(),
-  getAudioOutputDeviceInfo: jest.fn(),
+  getVideoDevices: jest.fn(),
+  getAudioInputDevices: jest.fn(),
+  getAudioOutputDevices: jest.fn(),
   CurrentAudioInputDevice: null,
   CurrentAudioOutputDevice: null,
   CurrentVideoDevice: null,

--- a/src/app/components/meeting/meeting.component.ts
+++ b/src/app/components/meeting/meeting.component.ts
@@ -2,18 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { DeviceManagerService } from '../../services/DeviceManager/deviceManager.service';
 
 @Component({
-  selector: 'app-meeting',
+  selector: 'pwui-meeting',
   templateUrl: './meeting.component.html',
-  styleUrls: ['./meeting.component.scss']
+  styleUrls: ['./meeting.component.scss'],
 })
 export class MeetingComponent implements OnInit {
+  constructor(public readonly deviceManager: DeviceManagerService) {}
 
-  constructor(private deviceManager: DeviceManagerService) { }
-
-  ngOnInit(): void {
-  }
-
-  getVideoDevices = () => this.deviceManager.getVideoDeviceInfo();
-  getAudioOutputDevices = () => this.deviceManager.getAudioOutputDeviceInfo();
-  getAudioInputDevices = () => this.deviceManager.getAudioInputDeviceInfo();
+  ngOnInit(): void {}
 }

--- a/src/app/components/meeting/meeting.module.ts
+++ b/src/app/components/meeting/meeting.module.ts
@@ -1,0 +1,11 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+
+import { MeetingComponent } from './meeting.component';
+
+@NgModule({
+  declarations: [MeetingComponent],
+  imports: [BrowserModule],
+  exports: [MeetingComponent],
+})
+export class MeetingModule {}

--- a/src/app/components/options/options.component.html
+++ b/src/app/components/options/options.component.html
@@ -1,6 +1,6 @@
 <select [(ngModel)]="selectedAudioInputId" (change)="updateAudioInput()">
   <option
-    *ngFor="let device of getAudioInputDevices()"
+    *ngFor="let device of deviceManager.getAudioInputDevices()"
     [value]="device.deviceId"
   >
     {{ device.deviceName }}
@@ -9,7 +9,7 @@
 
 <select [(ngModel)]="selectedAudioOutputId" (change)="updateAudioOutput()">
   <option
-    *ngFor="let device of getAudioOutputDevices()"
+    *ngFor="let device of deviceManager.getAudioOutputDevices()"
     [value]="device.deviceId"
   >
     {{ device.deviceName }}
@@ -17,7 +17,10 @@
 </select>
 
 <select [(ngModel)]="selectedVideoDeviceId" (change)="updateVideoDevice()">
-  <option *ngFor="let device of getVideoDevices()" [value]="device.deviceId">
+  <option
+    *ngFor="let device of deviceManager.getVideoDevices()"
+    [value]="device.deviceId"
+  >
     {{ device.deviceName }}
   </option>
 </select>

--- a/src/app/components/options/options.component.spec.ts
+++ b/src/app/components/options/options.component.spec.ts
@@ -7,27 +7,18 @@ import { DeviceManagerService } from '../../services/DeviceManager/deviceManager
 describe('OptionsComponent', () => {
   let component: OptionsComponent;
   let fixture: ComponentFixture<OptionsComponent>;
-  let mockDeviceManager = {
+  const mockDeviceManager = {
     updateMediaDevices: jest.fn(),
-    getVideoDeviceInfo: jest.fn(),
-    getAudioInputDeviceInfo: jest.fn(),
-    getAudioOutputDeviceInfo: jest.fn(),
+    getVideoDevices: jest.fn(),
+    getAudioInputDevices: jest.fn(),
+    getAudioOutputDevices: jest.fn(),
     CurrentAudioInputDevice: null,
     CurrentAudioOutputDevice: null,
     CurrentVideoDevice: null,
   };
 
   beforeEach(() => {
-    mockDeviceManager = {
-      updateMediaDevices: jest.fn(),
-      getVideoDeviceInfo: jest.fn(),
-      getAudioInputDeviceInfo: jest.fn(),
-      getAudioOutputDeviceInfo: jest.fn(),
-      CurrentAudioInputDevice: null,
-      CurrentAudioOutputDevice: null,
-      CurrentVideoDevice: null,
-    };
-
+    jest.clearAllMocks();
     TestBed.configureTestingModule({
       declarations: [OptionsComponent],
       imports: [FormsModule],
@@ -60,24 +51,6 @@ describe('OptionsComponent', () => {
     expect(component.selectedVideoDeviceId).toBe('video');
   });
 
-  it('getAudioInputDevices will return deviceManager getAudioInputDeviceInfo', () => {
-    const expectedValue = 'Test Return Value';
-    mockDeviceManager.getAudioInputDeviceInfo.mockReturnValue(expectedValue);
-    expect(component.getAudioInputDevices()).toBe(expectedValue);
-  });
-
-  it('getAudioOutputDevices will return deviceManager getAudioOutputDeviceInfo', () => {
-    const expectedValue = 'Test Return Value';
-    mockDeviceManager.getAudioOutputDeviceInfo.mockReturnValue(expectedValue);
-    expect(component.getAudioOutputDevices()).toBe(expectedValue);
-  });
-
-  it('getVideoDevices will return deviceManager getVideoDeviceInfo', () => {
-    const expectedValue = 'Test Return Value';
-    mockDeviceManager.getVideoDeviceInfo.mockReturnValue(expectedValue);
-    expect(component.getVideoDevices()).toBe(expectedValue);
-  });
-
   it('getCurrentAudioInputDevice will return deviceManager CurrentAudioInputDevice', () => {
     const expectedValue = 'Test Return Value';
     mockDeviceManager.CurrentAudioInputDevice = expectedValue;
@@ -99,7 +72,7 @@ describe('OptionsComponent', () => {
   it('updateAudioInput will set CurrentAudioInputDevice to be an input device with id matching selectedAudioInputId', () => {
     const expectedDevice = { deviceId: 'thisOne' };
     const inputDevices = [{ deviceId: 'notThis' }, expectedDevice];
-    mockDeviceManager.getAudioInputDeviceInfo.mockReturnValue(inputDevices);
+    mockDeviceManager.getAudioInputDevices.mockReturnValue(inputDevices);
     component.selectedAudioInputId = 'thisOne';
     component.updateAudioInput();
     expect(mockDeviceManager.CurrentAudioInputDevice).toBe(expectedDevice);
@@ -108,7 +81,7 @@ describe('OptionsComponent', () => {
   it('updateAudioOutput will set CurrentAudioOutputDevice to be an input device with id matching selectedAudioOutputId', () => {
     const expectedDevice = { deviceId: 'thisOne' };
     const outputDevices = [{ deviceId: 'notThis' }, expectedDevice];
-    mockDeviceManager.getAudioOutputDeviceInfo.mockReturnValue(outputDevices);
+    mockDeviceManager.getAudioOutputDevices.mockReturnValue(outputDevices);
     component.selectedAudioOutputId = 'thisOne';
     component.updateAudioOutput();
     expect(mockDeviceManager.CurrentAudioOutputDevice).toBe(expectedDevice);
@@ -117,7 +90,7 @@ describe('OptionsComponent', () => {
   it('updateVideoDevice will set CurrentVideoDevice to be an input device with id matching selectedVideoDeviceId', () => {
     const expectedDevice = { deviceId: 'thisOne' };
     const videoDevices = [{ deviceId: 'notThis' }, expectedDevice];
-    mockDeviceManager.getVideoDeviceInfo.mockReturnValue(videoDevices);
+    mockDeviceManager.getVideoDevices.mockReturnValue(videoDevices);
     component.selectedVideoDeviceId = 'thisOne';
     component.updateVideoDevice();
     expect(mockDeviceManager.CurrentVideoDevice).toBe(expectedDevice);

--- a/src/app/components/options/options.component.ts
+++ b/src/app/components/options/options.component.ts
@@ -3,7 +3,7 @@ import { DeviceManagerService } from 'src/app/services/DeviceManager/deviceManag
 import { AudioDevice } from 'src/app/services/DeviceManager/mediaDevices';
 
 @Component({
-  selector: 'app-options',
+  selector: 'pwui-options',
   templateUrl: './options.component.html',
   styleUrls: ['./options.component.scss'],
 })
@@ -12,7 +12,7 @@ export class OptionsComponent implements OnInit {
   selectedAudioInputId: string;
   selectedVideoDeviceId: string;
 
-  constructor(private deviceManager: DeviceManagerService) {}
+  constructor(public readonly deviceManager: DeviceManagerService) {}
 
   async ngOnInit(): Promise<void> {
     await this.deviceManager.updateMediaDevices();
@@ -21,24 +21,21 @@ export class OptionsComponent implements OnInit {
     this.selectedVideoDeviceId = this.deviceManager.CurrentVideoDevice?.deviceId;
   }
 
-  getAudioInputDevices = () => this.deviceManager.getAudioInputDeviceInfo();
   getCurrentAudioInputDevice = () => this.deviceManager.CurrentAudioInputDevice;
 
-  getAudioOutputDevices = () => this.deviceManager.getAudioOutputDeviceInfo();
   getCurrentAudioOutputDevice = () => this.deviceManager.CurrentAudioOutputDevice;
 
-  getVideoDevices = () => this.deviceManager.getVideoDeviceInfo();
   getCurrentVideoDevice = () => this.deviceManager.CurrentVideoDevice;
 
   updateAudioInput(): void {
-    this.deviceManager.CurrentAudioInputDevice = this.deviceManager.getAudioInputDeviceInfo().find((s) => s.deviceId === this.selectedAudioInputId);
+    this.deviceManager.CurrentAudioInputDevice = this.deviceManager.getAudioInputDevices().find((s) => s.deviceId === this.selectedAudioInputId);
   }
 
   updateAudioOutput(): void {
-    this.deviceManager.CurrentAudioOutputDevice = this.deviceManager.getAudioOutputDeviceInfo().find((s) => s.deviceId === this.selectedAudioOutputId);
+    this.deviceManager.CurrentAudioOutputDevice = this.deviceManager.getAudioOutputDevices().find((s) => s.deviceId === this.selectedAudioOutputId);
   }
 
   updateVideoDevice(): void {
-    this.deviceManager.CurrentVideoDevice = this.deviceManager.getVideoDeviceInfo().find((s) => s.deviceId === this.selectedVideoDeviceId);
+    this.deviceManager.CurrentVideoDevice = this.deviceManager.getVideoDevices().find((s) => s.deviceId === this.selectedVideoDeviceId);
   }
 }

--- a/src/app/components/options/options.module.ts
+++ b/src/app/components/options/options.module.ts
@@ -1,0 +1,12 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { OptionsComponent } from './options.component';
+
+@NgModule({
+  declarations: [OptionsComponent],
+  imports: [BrowserModule, FormsModule],
+  exports: [OptionsComponent],
+})
+export class OptionsModule {}

--- a/src/app/services/DeviceManager/deviceManager.service.spec.ts
+++ b/src/app/services/DeviceManager/deviceManager.service.spec.ts
@@ -346,9 +346,9 @@ describe('DeviceManagerService', () => {
       },
     ]);
     await service[updateMediaDevicesKey]();
-    expect(service.getAudioInputDeviceInfo().length).toBe(0);
-    expect(service.getAudioOutputDeviceInfo().length).toBe(0);
-    expect(service.getVideoDeviceInfo().length).toBe(0);
+    expect(service.getAudioInputDevices().length).toBe(0);
+    expect(service.getAudioOutputDevices().length).toBe(0);
+    expect(service.getVideoDevices().length).toBe(0);
   });
 
   it('upateMediaDevices populates the three device arrays, and sets current device to default if no config is present', async () => {
@@ -357,7 +357,7 @@ describe('DeviceManagerService', () => {
     mockMediaDevices.enumerateDevices.mockResolvedValue(testMediaDevices);
     await service[updateMediaDevicesKey]();
 
-    const audioInputs = service.getAudioInputDeviceInfo();
+    const audioInputs = service.getAudioInputDevices();
     expect(audioInputs).toHaveLength(2);
     expect(audioInputs[0].deviceId).toBe('1');
     expect(audioInputs[0].isDefault).toBe(true);
@@ -366,7 +366,7 @@ describe('DeviceManagerService', () => {
     expect(audioInputs[1].isDefault).toBe(false);
     expect(audioInputs[1].isCommunicationDefault).toBe(false);
 
-    const audioOutputs = service.getAudioOutputDeviceInfo();
+    const audioOutputs = service.getAudioOutputDevices();
     expect(audioOutputs).toHaveLength(2);
     expect(audioOutputs[0].deviceId).toBe('1');
     expect(audioOutputs[0].isDefault).toBe(true);
@@ -375,7 +375,7 @@ describe('DeviceManagerService', () => {
     expect(audioOutputs[1].isDefault).toBe(false);
     expect(audioOutputs[1].isCommunicationDefault).toBe(true);
 
-    const videoInputs = service.getVideoDeviceInfo();
+    const videoInputs = service.getVideoDevices();
     expect(videoInputs).toHaveLength(2);
     expect(videoInputs[0].deviceName).toBe('VI1');
     expect(videoInputs[1].deviceName).toBe('VI2');
@@ -387,7 +387,7 @@ describe('DeviceManagerService', () => {
     mockMediaDevices.enumerateDevices.mockResolvedValue(testMediaDevicesNoDefaults);
     await service[updateMediaDevicesKey]();
 
-    const audioInputs = service.getAudioInputDeviceInfo();
+    const audioInputs = service.getAudioInputDevices();
     expect(audioInputs).toHaveLength(2);
     expect(audioInputs[0].deviceId).toBe('1');
     expect(audioInputs[0].isDefault).toBe(false);
@@ -397,7 +397,7 @@ describe('DeviceManagerService', () => {
     expect(audioInputs[1].isCommunicationDefault).toBe(false);
     expect(service.CurrentAudioInputDevice).toBe(audioInputs[0]);
 
-    const audioOutputs = service.getAudioOutputDeviceInfo();
+    const audioOutputs = service.getAudioOutputDevices();
     expect(audioOutputs).toHaveLength(2);
     expect(audioOutputs[0].deviceId).toBe('1');
     expect(audioOutputs[0].isDefault).toBe(false);
@@ -407,7 +407,7 @@ describe('DeviceManagerService', () => {
     expect(audioOutputs[1].isCommunicationDefault).toBe(false);
     expect(service.CurrentAudioOutputDevice).toBe(audioOutputs[0]);
 
-    const videoInputs = service.getVideoDeviceInfo();
+    const videoInputs = service.getVideoDevices();
     expect(videoInputs).toHaveLength(2);
     expect(videoInputs[0].deviceName).toBe('VI1');
     expect(videoInputs[1].deviceName).toBe('VI2');

--- a/src/app/services/DeviceManager/deviceManager.service.ts
+++ b/src/app/services/DeviceManager/deviceManager.service.ts
@@ -161,7 +161,7 @@ export class DeviceManagerService {
     }
   }
 
-  public getVideoDeviceInfo = () => [...this.videoDevices.values()];
-  public getAudioInputDeviceInfo = () => [...this.audioInputDevices.values()];
-  public getAudioOutputDeviceInfo = () => [...this.audioOutputDevices.values()];
+  public getVideoDevices = () => [...this.videoDevices.values()];
+  public getAudioInputDevices = () => [...this.audioInputDevices.values()];
+  public getAudioOutputDevices = () => [...this.audioOutputDevices.values()];
 }


### PR DESCRIPTION
As noted in ng docs and tuts, it's not an antipattern to use services as public to use values in templates
https://angular.io/tutorial/toh-pt4#create-messagescomponent